### PR TITLE
Adding support for PATCH, LINK, & UNLINK.

### DIFF
--- a/Controller/Resource.php
+++ b/Controller/Resource.php
@@ -2,7 +2,7 @@
 
 abstract class Resauce_Controller_Resource extends Zend_Controller_Action
 {
-	private $allow = 'GET, PUT, POST, DELETE, HEAD, OPTIONS';
+	private $allow = 'GET, PUT, PATCH, LINK, UNLINK, POST, DELETE, HEAD, OPTIONS';
 
 	public function notAllowedAction() {
 		// Set Allow header and 405 Code
@@ -19,6 +19,18 @@ abstract class Resauce_Controller_Resource extends Zend_Controller_Action
 	}
 
 	public function putAction() {
+		$this->notAllowedAction();
+	}
+	
+	public function patchAction() {
+		$this->notAllowedAction();
+	}
+	
+	public function linkAction() {
+		$this->notAllowedAction();
+	}
+
+	public function unlinkAction() {
 		$this->notAllowedAction();
 	}
 

--- a/README.textile
+++ b/README.textile
@@ -20,7 +20,10 @@ i.e.
 
 * GET >> getAction()
 * PUT >> putAction()
+* PATCH >> patchAction()
 * POST >> postAction()
+* LINK >> linkAction()
+* UNLINK >> unlinkAction()
 * DELETE >> deleteAction()
 * HEAD >> headAction()
 * OPTIONS >> optionsAction()


### PR DESCRIPTION
Currently support is missing for verbs described in a few RFCs.
- `PATCH` - partially update a resource (`PUT` is a full replace)
- `LINK` - create a relationship between 2 resources
- `UNLINK` - remove a relationship between 2 resources

http://tools.ietf.org/html/rfc5789
http://tools.ietf.org/html/rfc5988
